### PR TITLE
[Mappings editor] Handle unsupported field types

### DIFF
--- a/x-pack/plugins/index_management/public/application/components/mappings_editor/lib/utils.ts
+++ b/x-pack/plugins/index_management/public/application/components/mappings_editor/lib/utils.ts
@@ -623,7 +623,7 @@ export const getFieldsMatchingFilterFromState = (
 } => {
   return Object.fromEntries(
     Object.entries(state.fields.byId).filter(([_, fieldId]) =>
-      filteredDataTypes.includes(TYPE_DEFINITION[state.fields.byId[fieldId.id].source.type].label)
+      filteredDataTypes.includes(getTypeLabelFromField(state.fields.byId[fieldId.id].source))
     )
   );
 };
@@ -646,9 +646,7 @@ export const getFieldsFromState = (
   const getField = (fieldId: string) => {
     if (filteredDataTypes) {
       if (
-        filteredDataTypes.includes(
-          TYPE_DEFINITION[normalizedFields.byId[fieldId].source.type].label
-        )
+        filteredDataTypes.includes(getTypeLabelFromField(normalizedFields.byId[fieldId].source))
       ) {
         return normalizedFields.byId[fieldId];
       }

--- a/x-pack/plugins/index_management/public/application/components/mappings_editor/use_state_listener.tsx
+++ b/x-pack/plugins/index_management/public/application/components/mappings_editor/use_state_listener.tsx
@@ -26,9 +26,9 @@ import {
   deNormalizeRuntimeFields,
   getAllFieldTypesFromState,
   getFieldsFromState,
+  getTypeLabelFromField,
 } from './lib';
 import { useMappingsState, useDispatch } from './mappings_state_context';
-import { TYPE_DEFINITION } from './constants';
 
 interface Args {
   onChange?: OnUpdateHandler;
@@ -56,7 +56,7 @@ export const useMappingsStateListener = ({ onChange, value, status }: Args) => {
     const allFieldsTypes = getAllFieldTypesFromState(deNormalize(normalize(mappedFields)));
     return allFieldsTypes.map((dataType) => ({
       checked: undefined,
-      label: TYPE_DEFINITION[dataType].label,
+      label: getTypeLabelFromField({ type: dataType }),
       'data-test-subj': `indexDetailsMappingsSelectFilter-${dataType}`,
     }));
   }, [mappedFields]);


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/197592

## Summary

This PR fixes the bug where the index Mappings details page crashes if the index has a mapping field with a type that is not recognized in Kibana.

**How to test:**
1. Create the following index in Console:
```
PUT test
{
  "mappings": {
    "properties": {
      "@timestamp": {
        "type": "date"
      },
      "log": {
        "type": "text"
      },
      "ids": {
        "type": "counted_keyword"
      }
    }
  }
}
```
2. Go to Index Management and click on the index that we just created
3. Go to Mappings page
4. Verify that the page loads correctly
5. Check that the opening filter and selecting an option doesn't make the page crash.


https://github.com/user-attachments/assets/7846cb5a-b25e-44fe-99d0-ac3ff36a714a




