### PR TITLE
Data source browser performance

### DIFF
--- a/src/platform/packages/private/kbn-esql-editor/src/custom_editor_commands.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/custom_editor_commands.ts
@@ -145,9 +145,11 @@ export const registerCustomCommands = (deps: MonacoCommandDependencies): monaco.
   commandDisposables.push(
     monaco.editor.registerCommand('esql.multiCommands', (...args) => {
       const [, { commands }] = args;
-      const commandsToExecute: { id: string; payload?: unknown }[] = JSON.parse(commands);
+      const commandsToExecute: { id: string; payload?: unknown; arguments?: unknown[] }[] =
+        JSON.parse(commands);
       commandsToExecute.forEach((command) => {
-        editorRef.current?.trigger(undefined, command.id, command.payload ?? {});
+        const payload = command.payload ?? command.arguments?.[0] ?? {};
+        editorRef.current?.trigger(undefined, command.id, payload);
       });
     })
   );

--- a/src/platform/packages/private/kbn-esql-editor/src/esql_editor.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/esql_editor.tsx
@@ -671,12 +671,16 @@ const ESQLEditorInternal = function ESQLEditor({
     esqlCallbacks,
   });
 
-  const { addSourcesDecorator, sourcesBadgeStyle, sourcesLabelClickHandler, sourcesLabelKeyDownHandler } =
-    useSourcesBadge({
-      editorRef,
-      editorModel,
-      openIndicesBrowser,
-    });
+  const {
+    addSourcesDecorator,
+    sourcesBadgeStyle,
+    sourcesLabelClickHandler,
+    sourcesLabelKeyDownHandler,
+  } = useSourcesBadge({
+    editorRef,
+    editorModel,
+    openIndicesBrowser,
+  });
 
   const queryRunButtonProperties = useMemo(() => {
     if (allowQueryCancellation && isLoading) {

--- a/src/platform/packages/private/kbn-esql-editor/src/resource_browser/use_resource_browser_badge.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/resource_browser/use_resource_browser_badge.tsx
@@ -20,7 +20,11 @@ interface UseSourcesBadgeParams {
   openIndicesBrowser: (options?: { openedFrom?: 'badge' | 'autocomplete' }) => void;
 }
 
-export const useSourcesBadge = ({ editorRef, editorModel, openIndicesBrowser }: UseSourcesBadgeParams) => {
+export const useSourcesBadge = ({
+  editorRef,
+  editorModel,
+  openIndicesBrowser,
+}: UseSourcesBadgeParams) => {
   const { euiTheme } = useEuiTheme();
   const decorationsRef = useRef<monaco.editor.IEditorDecorationsCollection | undefined>(undefined);
 
@@ -173,4 +177,3 @@ export const useSourcesBadge = ({ editorRef, editorModel, openIndicesBrowser }: 
     sourcesLabelKeyDownHandler,
   };
 };
-

--- a/src/platform/packages/private/kbn-esql-editor/src/resource_browser/utils.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/resource_browser/utils.ts
@@ -49,7 +49,10 @@ function isWordBoundary(text: string, index: number, isBefore: boolean): boolean
  * - Requires word boundaries so we don't match inside other tokens (e.g. `ts` in `?_tstart`)
  * - Returns the Monaco-style 1-based line/column start position
  */
-export function findFirstCommandPosition(query: string, command: string): CommandPosition | undefined {
+export function findFirstCommandPosition(
+  query: string,
+  command: string
+): CommandPosition | undefined {
   if (!query || !command) return;
 
   const lines = query.split('\n');
@@ -95,9 +98,13 @@ export const getLocatedSourceItemsFromQuery = (query: string): LocatedSourceItem
     const { root } = Parser.parse(query, { withFormatting: true });
     const sourceCommand = root.commands.find(({ name }) => name === 'from' || name === 'ts');
 
-    const sources = (sourceCommand?.args ?? []).filter(
-      (arg): arg is ESQLSource =>
-        Boolean(arg && typeof arg === 'object' && !Array.isArray(arg) && (arg as ESQLSource).type === 'source')
+    const sources = (sourceCommand?.args ?? []).filter((arg): arg is ESQLSource =>
+      Boolean(
+        arg &&
+          typeof arg === 'object' &&
+          !Array.isArray(arg) &&
+          (arg as ESQLSource).type === 'source'
+      )
     );
 
     return sources
@@ -239,4 +246,3 @@ export const computeInsertionText = ({
     text: `${needsLeadingComma ? ',' : ''}${sourceName}${needsTrailingComma ? ',' : ''}`,
   };
 };
-

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/registry/complete_items.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/registry/complete_items.ts
@@ -582,6 +582,7 @@ export function createResourceBrowserSuggestion(options: {
   rangeToReplace?: { start: number; end: number };
   filterText?: string;
   insertText?: string;
+  commandArgs?: Record<string, string>;
 }): ISuggestionItem {
   // TODO: The Timeseries suggestion still appears before the Resource Browser suggestion
   // We should fix this
@@ -593,6 +594,7 @@ export function createResourceBrowserSuggestion(options: {
     command: {
       title: options.label,
       id: options.commandId,
+      ...(options.commandArgs && { arguments: [options.commandArgs] }),
     },
     asSnippet: false,
     filterText: options.filterText || '',
@@ -603,7 +605,8 @@ export function createResourceBrowserSuggestion(options: {
 export function createIndicesBrowserSuggestion(
   rangeToReplace?: { start: number; end: number },
   filterText?: string,
-  insertText?: string
+  insertText?: string,
+  commandArgs?: Record<string, string>
 ): ISuggestionItem {
   return createResourceBrowserSuggestion({
     label: i18n.translate('kbn-esql-language.esql.autocomplete.indicesBrowser.suggestionLabel', {
@@ -619,5 +622,6 @@ export function createIndicesBrowserSuggestion(
     rangeToReplace,
     filterText,
     insertText,
+    commandArgs,
   });
 }

--- a/src/platform/packages/shared/kbn-esql-language/src/constants.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/constants.ts
@@ -8,3 +8,5 @@
  */
 
 export const TRANSFORMATIONAL_COMMANDS = ['keep', 'stats', 'promql'];
+export const MAX_PRELOADED_RESOURCE_ITEMS = 200;
+export const MAX_PRELOADED_RESOURCE_PAYLOAD = 20000;

--- a/src/platform/packages/shared/kbn-esql-language/src/language/autocomplete/autocomplete.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/language/autocomplete/autocomplete.ts
@@ -293,7 +293,6 @@ async function getSuggestionsWithinCommandExpression(
   const isSourceCommand = commandName === 'from' || commandName === 'ts';
   const isInsideSubquery = astContext.isCursorInSubquery; // We only show the resource browser in the main query
   if (isSourceCommand && callbacks?.isResourceBrowserEnabled && !isInsideSubquery) {
-    // Limit the number of items and payload size to avoid performance issues
     const { rangeToReplace, filterText } =
       suggestions.find((s) => s.rangeToReplace && s.filterText) ?? {};
     const insertText = rangeToReplace

--- a/src/platform/packages/shared/kbn-esql-language/src/language/autocomplete/autocomplete.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/language/autocomplete/autocomplete.ts
@@ -297,7 +297,21 @@ async function getSuggestionsWithinCommandExpression(
     const insertText = rangeToReplace
       ? fullText.substring(rangeToReplace.start, rangeToReplace.end)
       : '';
-    suggestions.unshift(createIndicesBrowserSuggestion(rangeToReplace, filterText, insertText));
+    const commandArgs: Record<string, string> = {};
+    if (context.sources) {
+      commandArgs.sources = JSON.stringify(context.sources);
+    }
+    if (context.timeSeriesSources) {
+      commandArgs.timeSeriesSources = JSON.stringify(context.timeSeriesSources);
+    }
+    suggestions.unshift(
+      createIndicesBrowserSuggestion(
+        rangeToReplace,
+        filterText,
+        insertText,
+        Object.keys(commandArgs).length ? commandArgs : undefined
+      )
+    );
   }
 
   // Apply context-aware ordering

--- a/src/platform/packages/shared/kbn-esql-language/src/language/autocomplete/autocomplete_utils.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/language/autocomplete/autocomplete_utils.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { ESQLSourceResult, IndexAutocompleteItem } from '@kbn/esql-types';
+import { MAX_PRELOADED_RESOURCE_ITEMS, MAX_PRELOADED_RESOURCE_PAYLOAD } from '../../constants';
+
+interface ResourceBrowserCommandArgsParams {
+  sources?: ESQLSourceResult[];
+  timeSeriesSources?: IndexAutocompleteItem[];
+}
+
+export const buildResourceBrowserCommandArgs = ({
+  sources,
+  timeSeriesSources,
+}: ResourceBrowserCommandArgsParams): Record<string, string> | undefined => {
+  const commandArgs: Record<string, string> = {};
+  // Limit the number of items and payload size to avoid performance issues
+  if (sources && sources.length <= MAX_PRELOADED_RESOURCE_ITEMS) {
+    const sourcesPayload = JSON.stringify(sources);
+    if (sourcesPayload.length <= MAX_PRELOADED_RESOURCE_PAYLOAD) {
+      commandArgs.sources = sourcesPayload;
+    }
+  }
+
+  if (timeSeriesSources && timeSeriesSources.length <= MAX_PRELOADED_RESOURCE_ITEMS) {
+    const timeSeriesPayload = JSON.stringify(timeSeriesSources);
+    if (timeSeriesPayload.length <= MAX_PRELOADED_RESOURCE_PAYLOAD) {
+      commandArgs.timeSeriesSources = timeSeriesPayload;
+    }
+  }
+
+  return Object.keys(commandArgs).length ? commandArgs : undefined;
+};


### PR DESCRIPTION
## Summary

Monaco commands allows you to pass arguments. I think we can safely pass here the sources (I added a safeguard). That way we don't need to retrieve sources twice, one for the editor autocomplete and the other for the browser indices




