### PR TITLE
Fixes the implementation of the fields browser

### DIFF
--- a/src/platform/packages/private/kbn-esql-editor/src/resource_browser/constants.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/resource_browser/constants.ts
@@ -10,6 +10,9 @@
 // Offset to account for the line height
 export const BROWSER_POPOVER_VERTICAL_OFFSET = 20;
 
+/** Fallback index pattern when the query has no source (e.g. empty or only processing commands). */
+export const DEFAULT_FIELDS_BROWSER_INDEX = '*';
+
 // Commands that should have a badge
 // Only FROM and TS commands support sources
 export const SUPPORTED_COMMANDS = ['from', 'ts'];

--- a/src/platform/packages/private/kbn-esql-editor/src/resource_browser/use_fields_browser.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/resource_browser/use_fields_browser.ts
@@ -38,7 +38,7 @@ interface BrowserPopoverPosition {
   left?: number;
 }
 
-const DEFAULT_FIELDS_BROWSER_INDEX = '.kibana';
+const DEFAULT_FIELDS_BROWSER_INDEX = '*';
 
 export function useFieldsBrowser({
   editorRef,

--- a/src/platform/packages/private/kbn-esql-editor/src/resource_browser/use_fields_browser.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/resource_browser/use_fields_browser.ts
@@ -21,7 +21,7 @@ import {
   getQueryWithoutLastPipe,
   getRangeFromOffsets,
 } from './utils';
-import { BROWSER_POPOVER_VERTICAL_OFFSET } from './constants';
+import { BROWSER_POPOVER_VERTICAL_OFFSET, DEFAULT_FIELDS_BROWSER_INDEX } from './constants';
 
 interface UseFieldsBrowserParams {
   editorRef: MutableRefObject<monaco.editor.IStandaloneCodeEditor | undefined>;
@@ -37,8 +37,6 @@ interface BrowserPopoverPosition {
   top?: number;
   left?: number;
 }
-
-const DEFAULT_FIELDS_BROWSER_INDEX = '*';
 
 export function useFieldsBrowser({
   editorRef,

--- a/src/platform/packages/private/kbn-esql-editor/src/resource_browser/use_fields_browser.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/resource_browser/use_fields_browser.ts
@@ -16,7 +16,11 @@ import type { ISearchGeneric } from '@kbn/search-types';
 import type { monaco } from '@kbn/monaco';
 import { BROWSER_POPOVER_WIDTH, DataSourceSelectionChange } from '@kbn/esql-resource-browser';
 import { getEditorExtensions, getEsqlColumns } from '@kbn/esql-utils';
-import { getLocatedSourceItemsFromQuery, getRangeFromOffsets } from './utils';
+import {
+  getLocatedSourceItemsFromQuery,
+  getQueryWithoutLastPipe,
+  getRangeFromOffsets,
+} from './utils';
 import { BROWSER_POPOVER_VERTICAL_OFFSET } from './constants';
 
 interface UseFieldsBrowserParams {
@@ -95,21 +99,21 @@ export function useFieldsBrowser({
 
   const fetchFields = useCallback(
     async (queryText: string) => {
-      // We only need a source command to retrieve fields. When the current query doesn't have
-      // any sources yet, fall back to a stable Kibana index so the browser can still function.
-      const mainSources = getLocatedSourceItemsFromQuery(queryText)
+      // Run the query without the last pipe so trailing incomplete commands (e.g. "| KEEP")
+      // are dropped and we get columns for the context the user is editing.
+      const queryToRun = getQueryWithoutLastPipe(queryText);
+      const mainSources = getLocatedSourceItemsFromQuery(queryToRun)
         .map((s) => s.name)
         .filter((name): name is string => Boolean(name));
       const indexPattern = mainSources.length
         ? mainSources.join(',')
         : DEFAULT_FIELDS_BROWSER_INDEX;
-      // `getColumnsFor` ultimately uses `getESQLQueryColumnsRaw()`, which appends `| limit 0`
-      // internally. So we pass a plain source query here (no extra LIMIT) to match the
-      // existing usage in `kbn-esql-language` (e.g. `fetchFields('FROM <index>')`).
-      const minimalQuery = `FROM ${indexPattern}`;
+      // When the trimmed query has no source command (e.g. only "| STATS ..."), fall back
+      // to a minimal FROM so the browser can still retrieve fields.
+      const esqlQuery = queryToRun && mainSources.length ? queryToRun : `FROM ${indexPattern}`;
 
       return await getEsqlColumns({
-        esqlQuery: minimalQuery,
+        esqlQuery,
         search,
         timeRange: getTimeRange(),
         signal,
@@ -134,15 +138,16 @@ export function useFieldsBrowser({
   );
 
   const openFieldsBrowser = useCallback(
-    async (options?: { preloadedFields?: string[] }) => {
+    async (options?: { preloadedFields?: Array<{ name: string; type?: string }> }) => {
       const model = editorModel.current;
       const editor = editorRef.current;
       if (!model || !editor) return;
 
       // Reset per-open-session state.
       insertedTextLengthRef.current = 0;
-      suggestedFieldNamesRef.current = options?.preloadedFields?.length
-        ? new Set(options.preloadedFields)
+      const preloadedFields = options?.preloadedFields;
+      suggestedFieldNamesRef.current = preloadedFields?.length
+        ? new Set(preloadedFields.map((f) => f.name))
         : undefined;
 
       const fullText = model.getValue() || '';
@@ -152,31 +157,51 @@ export function useFieldsBrowser({
       const cursorOffset = model.getOffsetAt(cursorPosition);
       insertAnchorOffsetRef.current = cursorOffset;
 
-      setIsLoadingFields(true);
-      try {
-        const [fetchedFields, fetchedRecommended] = await Promise.all([
-          fetchFields(fullText),
-          fetchRecommendedFields(fullText),
-        ]);
+      // If callers already have fields (e.g. from autocomplete context) we reuse them to avoid
+      // an extra async fetch, improving responsiveness.
+      const shouldUsePreloaded = Boolean(preloadedFields?.length);
 
-        const suggested = suggestedFieldNamesRef.current;
-        const filteredFields =
-          suggested && suggested.size
-            ? fetchedFields.filter((f) => suggested.has(f.name))
-            : fetchedFields;
+      if (shouldUsePreloaded && preloadedFields) {
+        const fieldsFromNames: ESQLFieldWithMetadata[] = preloadedFields.map((f) => ({
+          name: f.name,
+          type: (f.type as ESQLFieldWithMetadata['type']) ?? 'keyword',
+          userDefined: false,
+        }));
+        setAllFields(fieldsFromNames);
+        setIsLoadingFields(false);
+        // Recommended fields are always fetched (even when using preloaded fields).
+        fetchRecommendedFields(fullText).then((fetchedRecommended) => {
+          if (isMountedRef.current) {
+            setRecommendedFields(fetchedRecommended);
+          }
+        });
+      } else {
+        setIsLoadingFields(true);
+        try {
+          const [fetchedFields, fetchedRecommended] = await Promise.all([
+            fetchFields(fullText),
+            fetchRecommendedFields(fullText),
+          ]);
 
-        if (isMountedRef.current) {
-          setAllFields(filteredFields);
-          setRecommendedFields(fetchedRecommended);
-        }
-      } catch {
-        if (isMountedRef.current) {
-          setAllFields([]);
-          setRecommendedFields([]);
-        }
-      } finally {
-        if (isMountedRef.current) {
-          setIsLoadingFields(false);
+          const suggested = suggestedFieldNamesRef.current;
+          const filteredFields =
+            suggested && suggested.size
+              ? fetchedFields.filter((f) => suggested.has(f.name))
+              : fetchedFields;
+
+          if (isMountedRef.current) {
+            setAllFields(filteredFields);
+            setRecommendedFields(fetchedRecommended);
+          }
+        } catch {
+          if (isMountedRef.current) {
+            setAllFields([]);
+            setRecommendedFields([]);
+          }
+        } finally {
+          if (isMountedRef.current) {
+            setIsLoadingFields(false);
+          }
         }
       }
 

--- a/src/platform/packages/private/kbn-esql-editor/src/resource_browser/utils.test.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/resource_browser/utils.test.ts
@@ -13,6 +13,7 @@ import {
   findNextNonWhitespaceChar,
   findPrevNonWhitespaceChar,
   getLocatedSourceItemsFromQuery,
+  getQueryWithoutLastPipe,
   getSourceCommandContextFromQuery,
 } from './utils';
 import { IndicesBrowserOpenMode } from './open_mode';
@@ -281,6 +282,33 @@ describe('computeRemovalRange', () => {
     const range = computeRemovalRange(query, items, 'kibana_sample_data_logs');
     expect(range).toBeDefined();
     expect(query.slice(range!.start, range!.end)).toBe('kibana_sample_data_logs,');
+  });
+});
+
+describe('getQueryWithoutLastPipe', () => {
+  it('strips the last pipe and trailing command', () => {
+    expect(getQueryWithoutLastPipe('FROM kibana_sample_data_logs | STATS AVG(bytes) | KEEP')).toBe(
+      'FROM kibana_sample_data_logs | STATS AVG(bytes)'
+    );
+  });
+
+  it('returns full query when there is only one command', () => {
+    const query = 'FROM index';
+    expect(getQueryWithoutLastPipe(query)).toBe(query);
+  });
+
+  it('strips the last pipe when there are two commands (e.g. FROM ... | KEEP)', () => {
+    expect(getQueryWithoutLastPipe('FROM kibana_sample_data_logs | KEEP')).toBe(
+      'FROM kibana_sample_data_logs'
+    );
+  });
+
+  it('returns query without last command when there are two commands', () => {
+    expect(getQueryWithoutLastPipe('FROM a | STATS count(*)')).toBe('FROM a');
+  });
+
+  it('trims trailing whitespace and strips last command', () => {
+    expect(getQueryWithoutLastPipe('FROM a | STATS x | KEEP  \n  ')).toBe('FROM a | STATS x');
   });
 });
 

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/autocomplete/expressions/suggestion_builder.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/autocomplete/expressions/suggestion_builder.ts
@@ -53,7 +53,6 @@ export class SuggestionBuilder {
       promoteToTop,
       values,
       canBeMultiValue,
-      isFieldsBrowserEnabled: Boolean(this.context.context?.isFieldsBrowserEnabled),
     });
 
     this.suggestions.push(...fieldSuggestions);

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/autocomplete/helpers.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/autocomplete/helpers.ts
@@ -31,8 +31,6 @@ import { filterFunctionDefinitions, getAllFunctions, getFunctionSuggestion } fro
 import { SuggestionCategory } from '../../../../language/autocomplete/utils/sorting/types';
 import { buildConstantsDefinitions, getCompatibleLiterals, getDateLiterals } from '../literals';
 import { getColumnByName } from '../shared';
-import { createFieldsBrowserSuggestion } from '../../../registry/complete_items';
-import { buildFieldsBrowserCommandArgs } from '../../../../language/autocomplete/autocomplete_utils';
 
 export const shouldBeQuotedText = (
   text: string,
@@ -151,7 +149,6 @@ interface FieldSuggestionsOptions {
   addComma?: boolean;
   promoteToTop?: boolean;
   canBeMultiValue?: boolean;
-  isFieldsBrowserEnabled?: boolean;
 }
 
 export async function getFieldsSuggestions(
@@ -167,7 +164,6 @@ export async function getFieldsSuggestions(
     addComma = false,
     promoteToTop = true,
     canBeMultiValue = false,
-    isFieldsBrowserEnabled = false,
   } = options;
 
   const variableType = (() => {
@@ -182,13 +178,6 @@ export async function getFieldsSuggestions(
     addComma,
     variableType,
   });
-
-  if (isFieldsBrowserEnabled) {
-    const commandArgs = buildFieldsBrowserCommandArgs({
-      fields: suggestions.map((suggestion) => suggestion.label),
-    });
-    suggestions.unshift(createFieldsBrowserSuggestion(commandArgs));
-  }
 
   return pushItUpInTheList(suggestions as ISuggestionItem[], promoteToTop);
 }

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/functions.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/functions.ts
@@ -29,6 +29,8 @@ import type { ESQLColumnData, ISuggestionItem } from '../../registry/types';
 import { withAutoSuggest } from './autocomplete/helpers';
 import { buildFunctionDocumentation } from './documentation';
 import { getSafeInsertText, getControlSuggestion } from './autocomplete/helpers';
+import { buildFieldsBrowserCommandArgs } from '../../../language/autocomplete/autocomplete_utils';
+import { createFieldsBrowserSuggestion } from '../../registry/complete_items';
 import type { ESQLAstItem, ESQLFunction } from '../../../types';
 import { removeFinalUnknownIdentiferArg, techPreviewLabel } from './shared';
 import { getTestFunctions } from './test_functions';
@@ -434,6 +436,7 @@ export const buildColumnSuggestions = (
     variableType?: ESQLVariableType;
     supportsControls?: boolean;
     supportsMultiValue?: boolean;
+    isFieldsBrowserEnabled?: boolean;
   },
   variables?: ESQLControlVariable[]
 ): ISuggestionItem[] => {
@@ -488,6 +491,13 @@ export const buildColumnSuggestions = (
       )
     : [];
   suggestions.push(...controlSuggestions);
+
+  if (options?.isFieldsBrowserEnabled) {
+    const commandArgs = buildFieldsBrowserCommandArgs({
+      fields: columns.map((col) => ({ name: col.name, type: col.type })),
+    });
+    suggestions.unshift(createFieldsBrowserSuggestion(commandArgs));
+  }
 
   return [...suggestions];
 };

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/registry/completion/autocomplete.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/registry/completion/autocomplete.ts
@@ -133,7 +133,6 @@ export async function autocomplete(
           addSpaceAfterField: false,
           openSuggestions: false,
           promoteToTop: true,
-          isFieldsBrowserEnabled: Boolean(context?.isFieldsBrowserEnabled),
         }))
       );
 

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/registry/drop/autocomplete.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/registry/drop/autocomplete.ts
@@ -42,7 +42,6 @@ export async function autocomplete(
     ? await getFieldsSuggestions(['any'], callbacks.getByType, {
         ignoreColumns: alreadyDeclaredFields,
         promoteToTop: true,
-        isFieldsBrowserEnabled: Boolean(context?.isFieldsBrowserEnabled),
       })
     : [];
 

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/registry/drop/autocomplete.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/registry/drop/autocomplete.ts
@@ -17,7 +17,6 @@ import {
 } from '../../definitions/utils/autocomplete/helpers';
 import type { ICommandCallbacks } from '../types';
 import { type ISuggestionItem, type ICommandContext } from '../types';
-import { getFieldsSuggestions } from '../../definitions/utils';
 
 export async function autocomplete(
   query: string,
@@ -38,12 +37,7 @@ export async function autocomplete(
   const alreadyDeclaredFields = (command as ESQLCommand).args
     .filter(isColumn)
     .map((arg) => arg.name);
-  const fieldSuggestions = callbacks?.getByType
-    ? await getFieldsSuggestions(['any'], callbacks.getByType, {
-        ignoreColumns: alreadyDeclaredFields,
-        promoteToTop: true,
-      })
-    : [];
+  const fieldSuggestions = (await callbacks?.getByType?.('any', alreadyDeclaredFields)) ?? [];
 
   return handleFragment(
     innerText,

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/registry/keep/autocomplete.test.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/registry/keep/autocomplete.test.ts
@@ -10,7 +10,6 @@ import { mockContext } from '../../../__tests__/commands/context_fixtures';
 import { autocomplete } from './autocomplete';
 import { expectSuggestions } from '../../../__tests__/commands/autocomplete';
 import type { ICommandCallbacks } from '../types';
-import { buildFieldsDefinitionsWithMetadata } from '../../definitions/utils';
 
 const keepExpectSuggestions = (
   query: string,
@@ -44,37 +43,5 @@ describe('KEEP Autocomplete', () => {
 
   it('suggests command and pipe after a field has been used in KEEP', async () => {
     keepExpectSuggestions('FROM logs* | KEEP doubleField ', ['| ', ',']);
-  });
-
-  it('prepends the fields browser suggestion when enabled', async () => {
-    const result = await autocomplete(
-      'FROM a | KEEP ',
-      { args: [] } as any,
-      {
-        getByType: jest.fn(async () =>
-          buildFieldsDefinitionsWithMetadata([], [], { isFieldsBrowserEnabled: true })
-        ),
-      } as any,
-      { ...mockContext, isFieldsBrowserEnabled: true } as any,
-      'FROM a | KEEP '.length
-    );
-
-    const containsFieldsBrowserCommand = result.some((s) => {
-      const cmd = s.command;
-      if (!cmd) return false;
-
-      if (cmd.id === 'esql.fieldsBrowser.open') return true;
-
-      if (cmd.id === 'esql.multiCommands') {
-        const payload = cmd.arguments?.[0]?.commands;
-        if (!payload) return false;
-        const commands = JSON.parse(payload) as Array<{ id: string }>;
-        return commands.some((c) => c.id === 'esql.fieldsBrowser.open');
-      }
-
-      return false;
-    });
-
-    expect(containsFieldsBrowserCommand).toBe(true);
   });
 });

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/registry/keep/autocomplete.test.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/registry/keep/autocomplete.test.ts
@@ -10,6 +10,7 @@ import { mockContext } from '../../../__tests__/commands/context_fixtures';
 import { autocomplete } from './autocomplete';
 import { expectSuggestions } from '../../../__tests__/commands/autocomplete';
 import type { ICommandCallbacks } from '../types';
+import { buildFieldsDefinitionsWithMetadata } from '../../definitions/utils';
 
 const keepExpectSuggestions = (
   query: string,
@@ -49,7 +50,11 @@ describe('KEEP Autocomplete', () => {
     const result = await autocomplete(
       'FROM a | KEEP ',
       { args: [] } as any,
-      { getByType: jest.fn(async () => []) } as any,
+      {
+        getByType: jest.fn(async () =>
+          buildFieldsDefinitionsWithMetadata([], [], { isFieldsBrowserEnabled: true })
+        ),
+      } as any,
       { ...mockContext, isFieldsBrowserEnabled: true } as any,
       'FROM a | KEEP '.length
     );

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/registry/keep/autocomplete.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/registry/keep/autocomplete.ts
@@ -17,7 +17,6 @@ import {
   handleFragment,
 } from '../../definitions/utils/autocomplete/helpers';
 import { isColumn } from '../../../ast/is';
-import { getFieldsSuggestions } from '../../definitions/utils';
 
 export async function autocomplete(
   query: string,
@@ -38,13 +37,7 @@ export async function autocomplete(
   const alreadyDeclaredFields = (command as ESQLCommand).args
     .filter(isColumn)
     .map((arg) => arg.parts.join('.'));
-  const fieldSuggestions = callbacks?.getByType
-    ? await getFieldsSuggestions(['any'], callbacks.getByType, {
-        ignoreColumns: alreadyDeclaredFields,
-        promoteToTop: true,
-      })
-    : [];
-
+  const fieldSuggestions = (await callbacks?.getByType?.('any', alreadyDeclaredFields)) ?? [];
   return handleFragment(
     innerText,
     (fragment) => columnExists(fragment, context),

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/registry/keep/autocomplete.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/registry/keep/autocomplete.ts
@@ -42,7 +42,6 @@ export async function autocomplete(
     ? await getFieldsSuggestions(['any'], callbacks.getByType, {
         ignoreColumns: alreadyDeclaredFields,
         promoteToTop: true,
-        isFieldsBrowserEnabled: Boolean(context?.isFieldsBrowserEnabled),
       })
     : [];
 

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/registry/types.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/registry/types.ts
@@ -110,6 +110,8 @@ export type GetColumnsByTypeFn = (
     openSuggestions?: boolean;
     addComma?: boolean;
     variableType?: ESQLVariableType;
+    /** When true, prepends a "Browse fields" suggestion with current columns as preloaded fields. */
+    isFieldsBrowserEnabled?: boolean;
   }
 ) => Promise<ISuggestionItem[]>;
 

--- a/src/platform/packages/shared/kbn-esql-language/src/language/autocomplete/autocomplete.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/language/autocomplete/autocomplete.ts
@@ -272,12 +272,20 @@ async function getSuggestionsWithinCommandExpression(
     unmappedFieldsStrategy,
   };
 
+  // Wrap getColumnsByType so the fields browser option is injected from context;
+  // command autocompletes and getFieldsSuggestions stay agnostic.
+  const getByTypeWithContext: GetColumnsByTypeFn = (type, ignored, options) =>
+    getColumnsByType(type, ignored, {
+      ...options,
+      isFieldsBrowserEnabled: context.isFieldsBrowserEnabled,
+    });
+
   // does it make sense to have a different context per command?
   const suggestions = await commandDefinition.methods.autocomplete(
     fullText,
     astContext.command,
     {
-      getByType: getColumnsByType,
+      getByType: getByTypeWithContext,
       getSuggestedUserDefinedColumnName,
       getColumnsForQuery: callbacks?.getColumnsFor
         ? async (query: string) => {

--- a/src/platform/packages/shared/kbn-esql-language/src/language/autocomplete/autocomplete_utils.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/language/autocomplete/autocomplete_utils.ts
@@ -44,15 +44,22 @@ export const buildResourceBrowserCommandArgs = ({
   return Object.keys(commandArgs).length ? commandArgs : undefined;
 };
 
+export interface PreloadedFieldItem {
+  name: string;
+  type?: string;
+}
+
 interface FieldsBrowserCommandArgsParams {
-  fields?: string[];
+  /** Suggested fields (name + optional type) used to preload the fields browser list. */
+  fields?: PreloadedFieldItem[];
 }
 
 /**
  * Builds the (optional) command payload for the "Browse fields" autocomplete item.
  *
- * The payload is a JSON-encoded list of suggested fields used to filter the fields browser list.
- * This is not a pre-selection — the fields browser always opens with no selected field.
+ * The payload is a JSON-encoded list of suggested fields (name and type) used to preload the
+ * fields browser list. This is not a pre-selection — the fields browser always opens with
+ * no selected field.
  */
 export const buildFieldsBrowserCommandArgs = ({
   fields,


### PR DESCRIPTION
## Summary

This PR:

- fixes the preloaded fields logic, we were running the getColumns call even if they were present
- we are getting now the types too
- fixed the behavior inside the kbn-esql-language in order to work as expected


